### PR TITLE
fixed mime.types missing warning from Icecast :boom:

### DIFF
--- a/balenaPhono/Dockerfile.template
+++ b/balenaPhono/Dockerfile.template
@@ -2,11 +2,12 @@ FROM balenalib/%%BALENA_MACHINE_NAME%%-debian-python:3.9-buster
 
 WORKDIR /app
 
-RUN install_packages alsa-utils darkice icecast2
+RUN install_packages alsa-utils darkice icecast2 mime-support
 
 # This will copy all files in our root to the working  directory in the container
 COPY . ./
 
+# Checks for env vars and creates the config files.
 RUN python3 phonoConfig.py
 
 # Enable udevd so that plugged dynamic hardware devices show up in our container.


### PR DESCRIPTION
Tested on pi zero W. The WARN (WARN fserve/fserve_recheck_mime_types Cannot open mime types file /etc/mime.types) is gone!

Fix: Install `mime-support` package with all the other depends and apps. It isn't in the base image apparently.

Good to be merged into Main.

Checked by Sam//2022